### PR TITLE
workspace: add bazel rule

### DIFF
--- a/strobfus.bzl
+++ b/strobfus.bzl
@@ -1,0 +1,31 @@
+def strobfus_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".strobfus.go")
+    args = ctx.actions.args()
+    args.add_all("-filename", [ctx.file.src])
+    args.add_all("-output", [out])
+    ctx.actions.run(
+        inputs = [ctx.file.src],
+        outputs = [out],
+        executable = ctx.executable._strobfus,
+        arguments = [args],
+    )
+    return [
+        DefaultInfo(
+            files = depset([out]),
+        ),
+    ]
+
+strobfus = rule(
+    strobfus_impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "_strobfus": attr.label(
+            cfg = "host",
+            executable = True,
+            default = "//:strobfus",
+        ),
+    }
+)


### PR DESCRIPTION
The rule can be used by adding to the WORKSPACE:
```python
	go_repository(
	    name = "com_github_znly_strobfus",
	    commit = "3c365481460bf195be8ebb994d52cadd0726916a",
	    importpath = "github.com/znly/strobfus",
	)
```
And then:
```python
	load("@io_bazel_rules_go//go:def.bzl", "go_library")
	load("@com_github_znly_strobfus//:strobfus.bzl", "strobfus")

	strobfus(
	    name = "mystrings",
	    src = "strings.go",
	)

	go_library(
	    name = "go_default_library",
	    srcs = [":mystrings"],
	    importpath = "github.com/my/package",
	    visibility = ["//visibility:public"],
	)
```